### PR TITLE
Serverless v1.39.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,6 @@ RUN apk add --no-cache \
 
 ENV NODE_ENV development
 
-RUN yarn global add serverless@1.39.0
+RUN yarn global add serverless@1.39.1
 
 ENTRYPOINT ["/bin/bash", "-c"]


### PR DESCRIPTION
Bump serverless version to `v1.39.1`.

An [issue](https://github.com/serverless/serverless/issues/5928#issuecomment-473849971) was introduced in `v1.39.0` which prevented deployments from working correctly in CI environments.

This PR bumps the version to [v1.39.1](https://github.com/serverless/serverless/releases/tag/v1.39.1) which has reverted the commit which caused the bug.